### PR TITLE
[12.0][IMP] web_editor: Improve compatibility of getMatchedCSSRules

### DIFF
--- a/addons/web_editor/static/src/js/editor/transcoder.js
+++ b/addons/web_editor/static/src/js/editor/transcoder.js
@@ -28,6 +28,9 @@ function getMatchedCSSRules(a) {
             if (rules) {
                 for (r = rules.length-1; r >= 0; r--) {
                     var selectorText = rules[r].selectorText;
+                    if(selectorText && selectorText.includes(":is(")) {
+                        selectorText = selectorText.replace(/:is\((.*?)\)/g, "$1");
+                    }
                     if (selectorText &&
                             rules[r].cssText &&
                             selectorText !== '*' &&


### PR DESCRIPTION
This PR addresses an issue where the `getMatchedCSSRules` function incorrectly splits CSS rules when the extension groups multiple selectors using :is(). 

